### PR TITLE
Fix Docker workflow to use GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [dev, stg, main]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   # Batch processing
   BATCH_SIZE: 50
@@ -34,18 +38,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: at-base
+          images: ghcr.io/${{ github.repository }}/at-base
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -101,18 +106,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: at-${{ matrix.module.name }}
+          images: ghcr.io/${{ github.repository }}/at-${{ matrix.module.name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
- Replace Docker Hub with GitHub Container Registry (ghcr.io)
- Use built-in GITHUB_TOKEN instead of external credentials
- Add proper permissions for package registry access
- No external secrets required for image publishing

🤖 Generated with [Claude Code](https://claude.ai/code)