### PR TITLE
Fix environment variable name in 09_transfer

### DIFF
--- a/src/core/_09_transfer.py
+++ b/src/core/_09_transfer.py
@@ -93,7 +93,7 @@ def transfer_item(media_item: dict) -> dict:
     :return: updated media dict that contains error info if applicable
     """
     # set directory env vars
-    download_dir = os.getenv('DOWNLOAD_DIR')
+    download_dir = os.getenv('AT_DOWNLOAD_DIR')
 
     try:
         utils.move_dir_or_file(


### PR DESCRIPTION
## Summary
- Fixed environment variable name from `DOWNLOAD_DIR` to `AT_DOWNLOAD_DIR` to match .env file
- Resolves NoneType error when running 09_transfer in Kubernetes

## Test plan
- [x] Verified env var name matches .env file
- [x] Tests pass
- [x] Docker builds complete
- [x] Merged through stg branch

🤖 Generated with [Claude Code](https://claude.ai/code)