### PR TITLE
Fix: copy uv.lock to container to prevent runtime package sync

### DIFF
--- a/containerization/dockerfile.00_base
+++ b/containerization/dockerfile.00_base
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy project files for installation
-COPY pyproject.toml ./
+COPY pyproject.toml uv.lock ./
 COPY src/ ./src/
 COPY config/ ./config/
 


### PR DESCRIPTION
- Added uv.lock to COPY command in dockerfile.00_base
- Prevents uv run from re-downloading packages at container startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)