### PR TITLE
Fix: allow season 0 for TV specials in target path generation

### DIFF
--- a/src/utils/local_file_operations.py
+++ b/src/utils/local_file_operations.py
@@ -211,8 +211,8 @@ def generate_tv_season_target_path(
     if season is None or not isinstance(season, int):
         raise ValueError("season must be a valid integer")
 
-    if season < 1:
-        raise ValueError("season must be greater than 0")
+    if season < 0:
+        raise ValueError("season cannot be negative")
 
     if season > 9999:
         raise ValueError("season must be 9999 or less")
@@ -262,8 +262,8 @@ def generate_tv_show_parent_path(
     if season is None or not isinstance(season, int):
         raise ValueError("season must be a valid integer")
 
-    if season < 1:
-        raise ValueError("season must be greater than 0")
+    if season < 0:
+        raise ValueError("season cannot be negative")
 
     if season > 9999:
         raise ValueError("season must be 9999 or less")
@@ -317,8 +317,8 @@ def generate_tv_show_target_path(
    if episode is None or not isinstance(episode, int):
        raise ValueError("episode must be a valid integer")
 
-   if season < 1:
-       raise ValueError("season must be greater than 0")
+   if season < 0:
+       raise ValueError("season cannot be negative")
 
    if episode < 1:
        raise ValueError("episode must be greater than 0")

--- a/tests/fixtures/core/_09_transfer_fixtures.py
+++ b/tests/fixtures/core/_09_transfer_fixtures.py
@@ -268,17 +268,17 @@ def generate_file_paths_cases():
             }
         },
         {
-            "description": "TV season with invalid season (0) sets error_condition",
+            "description": "TV season with negative season sets error_condition",
             "input": {
                 "hash": "errortvs0123456789012345678901234567890123",
                 "media_type": "tv_season",
                 "media_title": "Test Show",
                 "release_year": 2020,
-                "season": 0
+                "season": -1
             },
             "expected": {
                 "hash": "errortvs0123456789012345678901234567890123",
-                "error_condition": "error writing target_path - season must be greater than 0"
+                "error_condition": "error writing target_path - season cannot be negative"
             }
         },
         {

--- a/tests/fixtures/utils/local_file_operations_fixtures.py
+++ b/tests/fixtures/utils/local_file_operations_fixtures.py
@@ -272,6 +272,11 @@ def generate_tv_season_target_path_cases():
     """Test scenarios for generate_tv_season_target_path function."""
     return [
         {
+            "description": "Season 0 for specials",
+            "input": {"season": 0},
+            "expected": "s00"
+        },
+        {
             "description": "Single digit season with padding",
             "input": {"season": 1},
             "expected": "s01"
@@ -323,11 +328,6 @@ def generate_tv_season_target_path_error_cases():
             "expected_error": ValueError
         },
         {
-            "description": "Zero season raises ValueError",
-            "input": {"season": 0},
-            "expected_error": ValueError
-        },
-        {
             "description": "Negative season raises ValueError",
             "input": {"season": -1},
             "expected_error": ValueError
@@ -348,6 +348,16 @@ def generate_tv_season_target_path_error_cases():
 def generate_tv_show_parent_path_cases():
     """Test scenarios for generate_tv_show_parent_path function."""
     return [
+        {
+            "description": "Season 0 for specials",
+            "input": {
+                "root_dir": "/k/media/video/tv/",
+                "tv_show_name": "South Park",
+                "release_year": 1997,
+                "season": 0
+            },
+            "expected": PurePosixPath("/k/media/video/tv/south-park-1997/s00")
+        },
         {
             "description": "Standard TV show parent path",
             "input": {
@@ -395,12 +405,12 @@ def generate_tv_show_parent_path_error_cases():
     """Error test scenarios for generate_tv_show_parent_path function."""
     return [
         {
-            "description": "Invalid season raises ValueError",
+            "description": "Negative season raises ValueError",
             "input": {
                 "root_dir": "/k/media/video/tv/",
                 "tv_show_name": "Test Show",
                 "release_year": 2020,
-                "season": 0
+                "season": -1
             },
             "expected_error": ValueError
         },
@@ -420,6 +430,11 @@ def generate_tv_show_parent_path_error_cases():
 def generate_tv_show_target_path_cases():
     """Test scenarios for generate_tv_show_target_path function."""
     return [
+        {
+            "description": "Season 0 for specials",
+            "input": {"season": 0, "episode": 43},
+            "expected": "s00e43"
+        },
         {
             "description": "Single digit season and episode",
             "input": {"season": 1, "episode": 5},
@@ -472,8 +487,8 @@ def generate_tv_show_target_path_error_cases():
             "expected_error": ValueError
         },
         {
-            "description": "Zero season raises ValueError",
-            "input": {"season": 0, "episode": 1},
+            "description": "Negative season raises ValueError",
+            "input": {"season": -1, "episode": 1},
             "expected_error": ValueError
         },
         {


### PR DESCRIPTION
- Changed season validation from >= 1 to >= 0 in local_file_operations.py
- Season 0 is used by Plex for TV specials (e.g., South Park S00E43)
- Updated test fixtures to test negative seasons instead of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)