### PR TITLE
Fix: deduplicate by hash and tmdb_id to prevent metadata collection f…

### DIFF
--- a/src/core/_05_metadata_collection.py
+++ b/src/core/_05_metadata_collection.py
@@ -351,6 +351,9 @@ def process_media_with_existing_metadata(
         'media_title'
     ])
 
+    # Deduplicate by tmdb_id to avoid row multiplication during update
+    metadata_to_join = metadata_to_join.unique(subset=['tmdb_id'], keep='first')
+
     # Ensure all columns from metadata exist in media (add nulls for missing columns)
     for col in metadata_to_join.columns:
         if col not in media_with_metadata.columns:

--- a/src/data_models/media_schema.py
+++ b/src/data_models/media_schema.py
@@ -248,12 +248,12 @@ class MediaSchema(pa.DataFrameModel):
                 .otherwise(pl.lit(True))
         )
 
-        # Check unique hashes
+        # Deduplicate by hash, keeping first occurrence
         duplicates = df.filter(pl.col('hash').is_duplicated())
         if duplicates.height > 0:
             for row in duplicates.iter_rows(named=True):
-                print(f"Duplicate hash: {row['hash']}, Title: {row.get('original_title', 'N/A')}")
-            raise ValueError(f"Found {duplicates.height} duplicate hash(es)")
+                print(f"Warning: deduplicating hash {row['hash']}, Title: {row.get('original_title', 'N/A')}")
+            df = df.unique(subset=['hash'], keep='first')
 
         # Select schema columns in order
         df = df.select(MEDIA_SCHEMA_COLUMNS)


### PR DESCRIPTION
…ailures

- MediaSchema.validate() now deduplicates by hash (keeps first) instead of raising error
- process_media_with_existing_metadata deduplicates training table results by tmdb_id
- Prevents row multiplication when training table has duplicate tmdb_id entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)