### PR TITLE
Fix: handle year followed by delimiter in movie title extraction

### DIFF
--- a/src/utils/parse_element.py
+++ b/src/utils/parse_element.py
@@ -104,8 +104,8 @@ def extract_title(raw_title: str, media_type: str) -> str | None:
         if match:
             cleaned_title = match.group(1).strip()
         else:
-            # Try year without parentheses (space/delimiter before year)
-            match = re.search(r'(.+?)[\s._-]+((?:19|20)\d{2})(?:\s|$)', raw_title)
+            # Try year without parentheses (delimiter before year, delimiter/end after)
+            match = re.search(r'(.+?)[\s._-]+((?:19|20)\d{2})(?:[\s._-]|$)', raw_title)
             if match:
                 cleaned_title = match.group(1).strip()
             else:

--- a/tests/fixtures/utils/parse_elements_fixtures.py
+++ b/tests/fixtures/utils/parse_elements_fixtures.py
@@ -376,6 +376,25 @@ def extract_title_cases():
             "raw_title": "Task 2025 S01E01-02 1080p AMZN WEB-DL",
             "media_type": "tv_episode_pack",
             "expected": "Task"
+        },
+        # Issue 3: RARBG-style titles with year before resolution (from error investigation 2025-12-31)
+        {
+            "description": "Movie with year followed by period then resolution (RARBG style)",
+            "raw_title": "Raya.and.the.Last.Dragon.2021.1080p.WEBRip.x264-RARBG",
+            "media_type": "movie",
+            "expected": "Raya and the Last Dragon"
+        },
+        {
+            "description": "Movie with year followed by dash then resolution",
+            "raw_title": "Some-Movie-2023-1080p-BluRay-x264",
+            "media_type": "movie",
+            "expected": "Some Movie"
+        },
+        {
+            "description": "Movie with year followed by underscore then resolution",
+            "raw_title": "Another_Movie_2024_720p_WEB-DL",
+            "media_type": "movie",
+            "expected": "Another Movie"
         }
     ]
 


### PR DESCRIPTION
- Added test fixtures for RARBG-style titles (year.resolution pattern)
- Updated extract_title() regex to accept . - _ after year, not just space/end
- Fixes TMDB 404 for titles like "Raya.and.the.Last.Dragon.2021.1080p"

🤖 Generated with [Claude Code](https://claude.com/claude-code)