### PR TITLE
Promote dev to stg

### DIFF
--- a/src/core/_05_metadata_collection.py
+++ b/src/core/_05_metadata_collection.py
@@ -310,7 +310,7 @@ def collect_ratings(media_item: dict) -> dict:
             if data.get('Metascore', None) != "N/A":
                 media_item['metascore'] = data.get('Metascore')
             if data.get('imdbRating', None) != "N/A":
-                media_item['imdb_rating'] = float(data.get('imdbRating'))
+                media_item['imdb_rating'] = float(data.get('imdbRating')) * 10
             if data.get('imdbVotes', None) != "N/A":
                 media_item['imdb_votes'] = int(re.sub(r"\D", "", data.get('imdbVotes')))
             media_item['imdb_id'] = data.get('imdbID', None)

--- a/tests/unit/core/_05_metadata_collection_tests.py
+++ b/tests/unit/core/_05_metadata_collection_tests.py
@@ -70,9 +70,15 @@ class TestMetadataCollection:
             )
 
             if expected_count > 0:
-                for i in range(result.height):
-                    row = result.row(i, named=True)
-                    expected = expected_list[i]
+                # Build lookup by imdb_id for order-independent comparison
+                expected_by_id = {e['imdb_id']: e for e in expected_list}
+
+                for row in result.iter_rows(named=True):
+                    imdb_id = row.get('imdb_id')
+                    assert imdb_id in expected_by_id, (
+                        f"Unexpected imdb_id {imdb_id} in result for {case['description']}"
+                    )
+                    expected = expected_by_id[imdb_id]
 
                     # Check all expected fields
                     for field, expected_value in expected.items():


### PR DESCRIPTION
## Summary
- Direct training table write implementation complete
- Stage 05 writes metadata to atp.training with label=NULL
- Stage 06 updates labels based on rejection decision
- Anomalous items bypass reel-driver prediction
- MediaSchema slimmed down (metadata fields moved to training table)

## Test plan
- [x] All unit tests passing
- [x] Docker build successful
- [ ] Integration test in media-stg

🤖 Generated with [Claude Code](https://claude.com/claude-code)