### PR TITLE
Fix: use Docker Hub astral/uv image instead of GHCR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ test:
   tags:
     - k8s
     - docker
-  image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+  image: docker.io/astral/uv:python3.12-bookworm-slim
   before_script:
     - uv sync --dev
   script:


### PR DESCRIPTION
## Summary
- Switches test stage CI image from `ghcr.io/astral-sh/uv` to `docker.io/astral/uv`
- Fixes GitLab CI pipeline failures on main/stg branches where GHCR image pull was failing

## Context
The GitLab CI test stage was failing because the GHCR image requires authentication. Docker Hub image is publicly accessible.

## Test plan
- [ ] Verify GitLab CI pipeline passes on stg branch after merge
- [ ] Confirm AT container images are built with `:stg` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)